### PR TITLE
#12: Postgres Url changed for docker and bridge is removed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ COPY ./build/libs/adminconsole-0.0.1-SNAPSHOT.jar adminconsole.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "-Dspring.datasource.url=jdbc:postgresql://172.20.0.3:5432/nemeth","/adminconsole.jar"]
+ENTRYPOINT ["java", "-jar", "-Dspring.datasource.url=jdbc:postgresql://db:5432/nemeth","/adminconsole.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,6 @@ services:
     build: .
     ports:
       - "8080:8080"
-    networks:
-      network:
-        ipv4_address: 172.20.0.2
   db:
     image: postgres:latest
     environment:
@@ -18,17 +15,6 @@ services:
       - "5432:5432"
     volumes:
       - db_data:/var/lib/postgresql/data
-    networks:
-      network:
-        ipv4_address: 172.20.0.3
 
 volumes:
   db_data:
-
-networks:
-  network:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 172.20.0.0/16


### PR DESCRIPTION
The URL changed from a bridged IP address to the service's name. Bridge network is removed.